### PR TITLE
Inverse SnapPoint interface to be required instead of partial

### DIFF
--- a/packages/declaration/src/object.d.ts
+++ b/packages/declaration/src/object.d.ts
@@ -1883,7 +1883,7 @@ declare interface TTSObject<D extends ObjectData = ObjectData, C extends CustomO
    *
    * @category Global
    */
-  getSnapPoints(): SnapPoint[];
+  getSnapPoints(): Required<SnapPoint>[];
 
   /**
    * Data value of a variable in another Object's script.
@@ -1996,7 +1996,7 @@ declare interface TTSObject<D extends ObjectData = ObjectData, C extends CustomO
    *
    * @category Global
    */
-  setSnapPoints(snapPoints: Partial<SnapPoint>[]): boolean;
+  setSnapPoints(snapPoints: SnapPoint[]): boolean;
 
   /**
    * Creates/updates a global table variable in another entity's script.
@@ -2351,13 +2351,13 @@ type DecalAdd = Optional<Decal<VectorShape>, "position" | "rotation" | "scale">;
 
 interface SnapPoint {
   /** Local Position of the snap point. When attached to an object, position is relative to the object's center. */
-  position: VectorShape;
+  position?: VectorShape;
   /** Local Rotation of the snap point. When attached to an object, rotation is relative to the object's rotation. */
-  rotation: VectorShape;
+  rotation?: VectorShape;
   /** Whether the snap point is a rotation snap point. */
-  rotation_snap: boolean;
+  rotation_snap?: boolean;
   /** Table of representing the tags associated with the snap point. */
-  tags: string[];
+  tags?: string[];
 }
 
 type RotationValue = int | float | string;


### PR DESCRIPTION
Inverses the partial to be required and setting all fields to optional instead. This enables you to use the `SnapPoint` type itself for dynamically created snapPoints. It's easier to use with `setSnapPoints()` rather than having to use `Partial<SnapPoint>` every time.

Example:
```ts
function addSnapPoint(obj: TTSObject, snapPoint: SnapPoint) {
  const snaps: SnapPoint[] = obj.getSnapPoints()
  snaps.push(snapPoint)
  obj.setSnapPoints(snaps)
}
```