### PR TITLE
Fix onLoad and onSave params and return

### DIFF
--- a/packages/declaration/src/event.d.ts
+++ b/packages/declaration/src/event.d.ts
@@ -39,7 +39,7 @@ type OnFixedUpdateHandler = () => unknown;
  *
  * @param scriptState The previously saved script state i.e. value returned from onSave(...), or an empty string if there is no saved script state available.
  */
-type OnLoadHandler = (scriptState: Maybe<string>) => unknown;
+type OnLoadHandler = (scriptState: string) => unknown;
 
 /**
  * Called when an Object starts colliding with a collision registered Object.

--- a/packages/declaration/src/event.d.ts
+++ b/packages/declaration/src/event.d.ts
@@ -297,7 +297,7 @@ type OnPlayerTurnHandler = (player: Player, previousPlayer: Player) => unknown;
 /**
  * Called whenever a script needs to save its state.
  */
-type OnSaveHandler = () => Maybe<string>;
+type OnSaveHandler = () => string;
 
 /**
  * Called when a scripting button (numpad by default) is pressed. The index range that is returned is 1-10.


### PR DESCRIPTION
https://api.tabletopsimulator.com/events/#onload
> script_state: The previously saved script state i.e. value returned from [onSave(...)](https://api.tabletopsimulator.com/events/#onsave), or an empty string if there is no saved script state available.

https://api.tabletopsimulator.com/events/#onsave
> Return a `string`