### PR TITLE
(LuaLS) Add and improve behavior types

### DIFF
--- a/packages/declaration/lua/language-server/AssetBundle.def.lua
+++ b/packages/declaration/lua/language-server/AssetBundle.def.lua
@@ -1,5 +1,8 @@
 ---@meta
 
+---
+---The AssetBundle behavior is present on Objects that were created from a custom AssetBundle.
+---
 ---@class tts__AssetBundle
 AssetBundle = {}
 
@@ -7,19 +10,34 @@ AssetBundle = {}
 ---@field index number
 ---@field name string
 
+---
+--- Returns a Table with the keys "index" and "name" for each looping effect.
+---
 ---@return tts__AssetBundle_Effect[]
 function AssetBundle.getLoopingEffects() end
 
----@return number
+---
+--- Index of the currently looping effect. Indexes starts at 0.
+---
+---@return integer
 function AssetBundle.getLoopingEffectIndex() end
 
+---
+--- Returns a Table with the keys "index" and "name" for each trigger effect.
+---
 ---@return tts__AssetBundle_Effect[]
 function AssetBundle.getTriggerEffects() end
 
----@param index number
+---
+--- Starts playing a looping effect. Indexes starts at 0.
+---
+---@param index integer
 ---@return nil
 function AssetBundle.playLoopingEffect(index) end
 
----@param index number
+---
+--- Starts playing a trigger effect. Indexes starts at 0.
+---
+---@param index integer
 ---@return nil
 function AssetBundle.playTriggerEffect(index) end

--- a/packages/declaration/lua/language-server/Behaviours.lua
+++ b/packages/declaration/lua/language-server/Behaviours.lua
@@ -1,0 +1,202 @@
+---@meta
+
+---
+--- The Browser behavior is present on the Tablet Object.
+---
+--- **Example**
+---
+--- Instruct a Tablet Object to load the Tabletop Simulator homepage.
+--- ```
+--- object.Browser.url = "https://tabletopsimulator.com"
+--- ```
+---
+---@class tts__BrowserBehaviour
+---@field url string URL which currently wants to display.
+---@field pixel_width integer The pixel width the browser is virtually rendering to.
+local Browser = {}
+
+
+---
+--- The Clock behavior is present on the Digital Clock object.
+---
+--- Clock Modes
+--- - **Current Time**: Displays the current time of the host.
+--- - **Stopwatch**: Displays a running count up.
+--- - **Timer**: Displays a countdown and beeps once complete.
+---
+---@class tts__ClockBehaviour
+---@field paused boolean If the clock timer is paused.
+local Clock = {}
+
+---
+--- Current time in stopwatch or timer mode. Clock mode returns 0. This function acts the same as Object's getValue().
+---
+---@see tts__Object.getValue
+---@return integer
+function Clock.getValue() end
+
+---
+--- Pauses/resumes a Clock in stopwatch or timer mode.
+---
+---@return boolean
+function Clock.pauseStart() end
+
+---
+--- Set the timer to display a number of seconds. This function acts the same as Object's setValue(). If the Clock is not in timer mode, it will be switched. If it is in timer mode, it will be paused and the remaining time will be changed. This will not start the countdown on its own.
+---
+---@see tts__Object.setValue
+---@param seconds integer
+---@return boolean
+function Clock.setValue(seconds) end
+
+---
+--- Switches clock to display current time. It will clear any stopwatch or timer.
+---
+---@return boolean
+function Clock.showCurrentTime() end
+
+---
+--- Switches clock to stopwatch, setting time to 0. It will reset time if already in stopwatch mode.
+---
+---@return boolean
+function Clock.startStopwatch() end
+
+
+---
+--- The Counter behavior is present on the Counter object.
+---
+--- **Example**
+---
+--- Increment a counter's value.
+--- ```
+--- object.Counter.increment()
+--- ```
+---
+---@class tts__CounterBehaviour
+local Counter = {}
+
+---
+--- Resets Counter to 0.
+---
+---@return boolean
+function Counter.clear() end
+
+---
+--- Reduces Counter's value by 1.
+---
+---@return boolean
+function Counter.decrement() end
+
+---
+--- Returns Counter's current value. This function behaves the same as Object's getValue().
+---
+---@see tts__Object.getValue
+---@return integer
+function Counter.getValue() end
+
+---
+--- Increases Counter's value by 1.
+---
+---@return boolean
+function Counter.increment() end
+
+---
+--- Sets the current value of the Counter. This function behaves the same as Object's setValue().
+---
+---@see tts__Object.setValue
+---@param value integer
+---@return boolean
+function Counter.setValue(value) end
+
+
+---
+--- The RPGFigurine behavior is present on Objects that are figurines with built-in animations i.e. RPG Kit objects.
+---
+---@class tts__RPGFigurineBehaviour
+---@field onAttack nil | fun(hitObjects: tts__Object[]): void These are `RPGFigurine` member variables which can be assigned a function that will be executed in response to an event occurring.
+---@field onHit nil | fun(attacker: tts__Object): void        These are `RPGFigurine` member variables which can be assigned a function that will be executed in response to an event occurring.
+local RPGFigurine = {}
+
+---
+--- Executed when an attack is performed by the RPGFigurine Object.
+---
+--- An attack is triggered via the context menu or by pressing the appropriate number key. If another RPGFigurine is within its attack arc, then onHit will be executed on the other figurine.
+---
+---@see tts__RPGFigurineBehaviour.onHit
+---@param hitObjects tts__Object[] A table of RPGFigurine Objects within the reach of the attack.
+---@return void
+function RPGFigurine.onAttack(hitObjects) end
+
+---
+--- Executed when the RPGFigurine Object is hit by another attacking RPGFigure Object.
+---
+--- An attack is triggered via the context menu or by pressing the appropriate number key. If this RPGFigurine Object is within the attack radius of an attacker, this function will be executed.
+---
+---@param attacker tts__Object The RPGFigurine Object performing the attack.
+---@return void
+function RPGFigurine.onHit(attacker) end
+
+---
+--- Plays a random attack animation.
+---
+---@return boolean
+function RPGFigurine.attack() end
+
+---
+--- Changes the figurine's current mode. What the mode represents is based on the figurine.
+---
+---@return boolean
+function RPGFigurine.changeMode() end
+
+--- Plays the death animation or causes it to return to life.
+---
+---@return boolean
+function RPGFigurine.die() end
+
+
+---
+--- The TextTool behavior is present on 3DText objects i.e those created with the text tool.
+---
+---@class tts__TextToolBehaviour
+local TextTool = {}
+
+---
+--- Returns Table of font Color.
+---
+---@return tts__Color
+function TextTool.getFontColor() end
+
+---
+--- Returns Int of the font size.
+---
+---@return integer
+function TextTool.getFontSize() end
+
+---
+--- Returns the current text. Behaves the same as Object's getValue().
+---
+---@see tts__Object.getValue
+---@return string
+function TextTool.getValue() end
+
+---
+--- Sets font Color.
+---
+---@param font_color tts__ColorParameter
+---@return boolean
+function TextTool.setFontColor(font_color) end
+
+---
+--- Sets font size.
+---
+---@param font_size integer
+---@return boolean
+function TextTool.setFontSize(font_size) end
+
+---
+--- Sets the current text. Behaves the same as Object's setValue(...).
+---
+---@see tts__Object.setValue
+---@param text string
+---@return boolean
+function TextTool.setValue(text) end

--- a/packages/declaration/lua/language-server/Book.def.lua
+++ b/packages/declaration/lua/language-server/Book.def.lua
@@ -1,6 +1,10 @@
 ---@meta
 
+---
+--- The Book behavior is present on Custom PDF Objects. The Book behaviour allows you to manipulate the displayed PDF.
+---
 ---@class tts__BookBehaviour
+---@field page_offset integer The page numbers displayed in the Custom PDF UI are offset by this amount.<br>For example, if `page_offset` were set to 10, the first page in the UI would be 11, rather than 1. Negative numbers are accepted, and useful if a rule book contains a front cover, index etc. within the PDF file.
 local Book
 
 --- Clears the current highlight.
@@ -8,20 +12,32 @@ local Book
 function Book.clearHighlight() end
 
 --- Gets the current page of the PDF.
----@param offsetPageNumbering? boolean
+---@param offsetPageNumbering? boolean @Default false. Indicates whether or not page_offset should be applied to the page number returned.
 ---@return number
 function Book.getPage(offsetPageNumbering) end
 
---- Set highlight box on current page.S
----@param x1 number
----@param y1 number
----@param x2 number
----@param y2 number
+---
+--- Draws a highlight rectangle on the popout mode of the PDF at the given coordinates. Coordinates (0,0) are the lower left corner of the PDF, while coordinates (1,1) are the upper right corner.
+---
+---@param x1 number x coordinate of the rectangle's left side.
+---@param y1 number y coordinate of the rectangle's bottom side.
+---@param x2 number x coordinate of the rectangle's right side.
+---@param y2 number y coordinate of the rectangle's top side.
+---
+--- **Example**
+---
+--- Highlight the upper right quarter of a PDF.
+--- ```
+--- object.Book.setHighlight(0.5, 0.5, 1, 1)
+--- ```
+---
 ---@return boolean
 function Book.setHighlight(x1, y1, x2, y2) end
 
---- Set current page.
----@param page number
----@param offsetPageNumbering? boolean
+---
+--- Sets the current page of the PDF. Returns true if the page was succesfully set, false if the page number was invalid.
+---
+---@param page number The new page number.
+---@param offsetPageNumbering? boolean @Default false. Indicates whether or not page_offset should be applied to the page number set.
 ---@return boolean
 function Book.setPage(page, offsetPageNumbering) end

--- a/packages/declaration/lua/language-server/Callbacks.def.lua
+++ b/packages/declaration/lua/language-server/Callbacks.def.lua
@@ -50,7 +50,7 @@ tryObjectEnter = nil
 ---
 --- Return `false` to prevent the object entering.
 ---
----@type nil | fun(container: tts__Container, object: tts__Object): boolean|void
+---@type nil | fun(container: tts__Card | tts__Container, object: tts__Object): boolean|void
 tryObjectEnterContainer = nil
 
 ---
@@ -70,20 +70,20 @@ onObjectLeaveContainer = nil
 ---
 --- Called before an object changes state. Return false to prevent the state change.
 ---
----@type fun(new_state_index: integer, player_color: string): boolean|void
+---@type nil | fun(new_state_index: integer, player_color: string): boolean|void
 tryStateChange = nil
 
 ---
 --- Called when the script-owner Object spawned as a result of an Object state change.
 ---
----@type fun(new_state_index: integer, player_color: string): void
+---@type nil | fun(new_state_index: integer, player_color: string): void
 onStateChange = nil
 
 --- (GLOBAL SCRIPT ONLY)
 ---
 --- Called before an object changes state. Return false to prevent the state change.
 ---
----@type fun(object: tts__Object, new_state_index: integer, player_color: string): boolean|void
+---@type nil | fun(object: tts__Object, new_state_index: integer, player_color: string): boolean|void
 tryObjectStateChange = nil
 
 ---

--- a/packages/declaration/lua/language-server/Container.def.lua
+++ b/packages/declaration/lua/language-server/Container.def.lua
@@ -1,8 +1,22 @@
 ---@meta
 
+---
+--- The Container behavior is present on Container objects such as Bags, Stacks and Decks.
+---
 ---@class tts__ContainerBehaviour
 local Container
 
---- Opens the search window of the container for the given player.
----@param playerColor tts__PlayerColor
-function Container.Search(playerColor) end
+---
+---Show the Search window for the container to `player`. If you specify `max_cards` then the search will be limited to that many cards from the top of the deck.
+---
+---@param playerColor tts__PlayerColor The color of the player to show the Search window to.
+---@param max_cards? integer Optional maximum number of cards to show.
+---
+---**Example**
+---```
+---deck.Container.search(Player.Blue, 3)
+---```
+--- <br>
+function Container.search(playerColor, max_cards) end
+---@deprecated Use "search" instead
+Container.Search = Container.search

--- a/packages/declaration/lua/language-server/LayoutZone.lua
+++ b/packages/declaration/lua/language-server/LayoutZone.lua
@@ -7,10 +7,11 @@
 ---@class __tts__ZoneBaseBehaviour
 local Zone = {}
 
---- NOT IMPLEMENTED
----@deprecated
----@return nil
-function Zone.getObjects() end
+-- @TODO: hide/deprioritize in autocomplete
+-- --- NOT IMPLEMENTED
+-- ---@deprecated
+-- ---@return nil
+-- function Zone.getObjects() end
 
 ---
 --- The LayoutZone behavior is present on Layout Zones.

--- a/packages/declaration/lua/language-server/LayoutZone.lua
+++ b/packages/declaration/lua/language-server/LayoutZone.lua
@@ -1,0 +1,66 @@
+---@meta
+
+---
+--- The base type for a zone behavior. Doesn't do anything.
+---
+---@see tts__LayoutZoneBehaviour
+---@class __tts__ZoneBaseBehaviour
+local Zone = {}
+
+--- NOT IMPLEMENTED
+---@deprecated
+---@return nil
+function Zone.getObjects() end
+
+---
+--- The LayoutZone behavior is present on Layout Zones.
+---
+---@class tts__LayoutZoneBehaviour : __tts__ZoneBaseBehaviour
+local LayoutZone = {}
+
+---@class tts__LayoutZone_Options
+---@field allow_swapping boolean When moving an object from one full group to another, the object you drop on will be moved to the original group.
+---@field alternate_direction boolean Objects added to a group will be aligned up or right, different from the preceding object in the group. Used, for example, in trick-taking games to make counting easier.
+---@field cards_per_deck integer Sets the size of decks made by the layout zone when it combines newly added cards.
+---@field combine_into_decks boolean Whether cards added to the zone should be combined into decks. You may specify the number of cards per deck.
+---@field direction tts__LayoutZone_Direction The directions the groups in the zone expand into. This will determine the origin corner.
+---@field horizontal_group_padding number How much horizontal space is inserted between groups.
+---@field horizontal_spread number How far each object in a group is moved horizontally from the previous object.
+---@field instant_refill boolean When enabled, if ever a group is picked up or removed the rest of the layout will trigger to fill in the gap
+---@field manual_only boolean The zone will not automatically lay out objects: it must be triggered manually.
+---@field max_objects_per_group integer Each group in the zone may not contain more than this number of objects.
+---@field max_objects_per_new_group integer When new objects are added to a zone, they will be gathered into groups of this many objects.
+---@field meld_direction tts__LayoutZone_GroupDirection The direction the objects within a group will expand into.
+---@field meld_reverse_sort boolean When enabled the sort order inside a group is reversed
+---@field meld_sort tts__LayoutZone_GroupSort How groups are sorted internally.
+---@field meld_sort_existing boolean When enabled all groups will be sorted when laid out, rather than only newly added groups.
+---@field new_object_facing tts__LayoutZone_Facing Determines whether newly added objects are turned face-up or face-down.
+---@field randomize boolean Objects will be randomized whenever they are laid out
+---@field split_added_decks boolean Decks added to the zone will be split into their individual cards.
+---@field sticky_cards boolean When picked up, cards above the grabbed card will also be lifted.
+---@field trigger_for_face_down boolean Face-Down objects dropped on zone will be laid out.
+---@field trigger_for_face_up boolean Face-Up objects dropped on zone will be laid out.
+---@field trigger_for_non_cards boolean Non-card objects dropped on zone will be laid out
+---@field vertical_group_padding number How much vertical space is inserted between groups.
+---@field vertical_spread number How far each object in a group is moved vertically from the previous object.
+
+---@class (partial) tts__LayoutZoneBehaviour_OptionsParameter: tts__LayoutZone_Options
+
+---
+--- Returns the layout zones options.
+---
+---@return tts__LayoutZone_Options
+function LayoutZone.getOptions() end
+
+---
+--- Causes the layout zone to (re)layout.
+---
+---@return true
+function LayoutZone.layout() end
+
+---
+---Sets the layout zone's options. If an option is not included in the table, then the zone's value for that option will remain unchanged.
+---
+---@param options tts__LayoutZoneBehaviour_OptionsParameter
+---@return true
+function LayoutZone.setOptions(options) end

--- a/packages/declaration/lua/language-server/Object.def.lua
+++ b/packages/declaration/lua/language-server/Object.def.lua
@@ -685,7 +685,7 @@ function Object.getTable(name) end
 
 ---
 --- If the object is a bag, deck or stack, returns the number of objects within, otherwise -1.
----@return number
+---@return integer
 function Object.getQuantity() end
 
 ---@return any
@@ -761,13 +761,6 @@ function Object.removeButton(index) end
 ---@return true
 function Object.scale(scale) end
 
----@class tts__Object_DecalParameters
----@field name string
----@field url string
----@field position nil | tts__VectorShape @Default Vector(0, 0, 0)
----@field rotation nil | tts__VectorShape @Default Vector(0, 0, 0)
----@field scale nil | tts__VectorShape @Default Vector(1, 1, 1)
-
 ---@param color tts__ColorShape
 ---@return boolean
 function Object.setColorTint(color) end
@@ -787,6 +780,13 @@ function Object.setColorTint(color) end
 
 ---@param parameters tts__Object_CustomObject_In
 function Object.setCustomObject(parameters) end
+
+---@class tts__Object_DecalParameters
+---@field name string
+---@field url string
+---@field position nil | tts__VectorShape @Default Vector(0, 0, 0)
+---@field rotation nil | tts__VectorShape @Default Vector(0, 0, 0)
+---@field scale nil | tts__VectorShape @Default Vector(1, 1, 1)
 
 ---
 --- Removes all existing decals, replacing them with a decal per entry in the provided decal parameters array.
@@ -926,8 +926,8 @@ function Object.setRotationSmooth(rotation, collide, fast) end
 ---@see tts__Object#getRotationValues
 function Object.setRotationValue(value) end
 
----@param newValue string
----@return any
+---@param newValue integer | string
+---@return boolean
 function Object.setValue(newValue) end
 
 ---@param name string

--- a/packages/declaration/lua/language-server/Object.def.lua
+++ b/packages/declaration/lua/language-server/Object.def.lua
@@ -28,8 +28,17 @@
 ---@field min_distance nil | number
 
 ---@class tts__Object : tts__GameObject
+---@field AssetBundle tts__AssetBundle?          @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field Book        tts__BookBehaviour?        @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field Browser     tts__BrowserBehaviour?     @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field Clock       tts__ClockBehaviour?       @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field Counter     tts__CounterBehaviour?     @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field Container   tts__ContainerBehaviour?   @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field LayoutZone  tts__LayoutZoneBehaviour?  @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field RPGFigurine tts__RPGFigurineBehaviour? @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field TextTool    tts__TextToolBehaviour?    @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field Zone        __tts__ZoneBaseBehaviour?  @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 ---@field angular_drag number
----@field AssetBundle tts__AssetBundle  @[Read only]
 ---@field auto_raise boolean
 ---@field bounciness number
 ---@field drag number
@@ -71,17 +80,18 @@
 local Object
 
 ---@class tts__Book : tts__Object
----@field Book tts__BookBehaviour
+---@field Book tts__BookBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 
 --- The following are not real types in TTS, but this allows us to strongly type our code where an object of a specific type is required.
 --- NOTE: There is no tts__AssetBundle or tts__Model, because these objects always masquerade as another object type.
 
 
 ---@class tts__Container : tts__Object
----@field Container tts__ContainerBehaviour
+---@field Container tts__ContainerBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 local Container
 
 ---@class tts__Stackable : tts__Object
+---@field Container tts__ContainerBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 local Stackable
 
 ---@class tts__BackgammonPiece : tts__Object
@@ -107,10 +117,12 @@ local CardCustom
 ---@class tts__Chip : tts__Stackable
 
 ---@class tts__Clock : tts__Object
+---@field Clock tts__ClockBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 
 ---@class tts__Coin : tts__Object
 
 ---@class tts__Counter : tts__Object
+---@field Counter tts__CounterBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 
 ---@class tts__Deck : tts__Container
 
@@ -122,7 +134,17 @@ local DeckCustom
 ---@class tts__DieCustom : tts__Die
 local DieCustom
 
----@class Hand : tts__Object
+---@class tts__Domino : tts__Object
+
+---@class tts__Figurine : tts__Object
+
+---@class tts__Fog : tts__Zone
+
+---@class tts__FogOfWar : tts__Zone
+
+---@class tts__GoPiece : tts__Object
+
+---@class tts__Hand : tts__Zone
 local Hand
 
 ---@return tts__PlayerHandColor
@@ -132,19 +154,7 @@ function Hand.getValue() end
 ---@return boolean
 function Hand.setValue(newValue) end
 
----@class tts__Domino : tts__Object
-
----@class tts__Figurine : tts__Object
-
----@class tts__Fog : tts__Object
-
----@class tts__FogOfWar : tts__Object
-
----@class tts__GoPiece : tts__Object
-
----@class tts__Hand : tts__Object
-
----@class tts__Infinite : tts__Object
+---@class tts__Infinite : tts__Container
 
 ---@class tts__InventoryBackground : tts__Object
 
@@ -164,20 +174,30 @@ function Hand.setValue(newValue) end
 
 ---@class tts__Pointer : tts__Object
 
----@class tts__Randomize : tts__Object
+---@class tts__Randomize : tts__Zone
 
 ---@class tts__RPGFigurine : tts__Object
+---@field RPGFigurine tts__RPGFigurineBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 
----@class tts__ScriptingTrigger : tts__Object
-local ScriptingTrigger
+---@class tts__ScriptingTrigger : tts__Zone
+
+---@class tts__Zone : tts__Object
+---@field Zone __tts__ZoneBaseBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+local Zone
+
+---@class tts__LayoutZone : tts__Zone
+---@field Zone       tts__LayoutZoneBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
+---@field LayoutZone tts__LayoutZoneBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 
 ---@class tts__Superfight : tts__Object
 
 ---@class tts__Surface : tts__Object
 
 ---@class tts__Tablet : tts__Object
+---@field Browser tts__BrowserBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 
 ---@class tts__Text : tts__Object
+---@field TextTool tts__TextToolBehaviour @[Read only] <br>Some objects provide additional behavior. This functionality is accessible as Object member variables, but will be nil unless the Object includes the behavior.
 
 ---@class tts__Tile : tts__Stackable
 local Tile
@@ -563,19 +583,19 @@ function Object.getName() end
 ---@class tts__IndexedSimpleObjectState : tts__SimpleObjectState
 ---@field index number
 
---- If this object is a scripting trigger, bag or deck, returns the objects contained within. Otherwise, logs an error and returns nil
+--- If this object is a zone, bag or deck, returns the objects contained within. Otherwise, logs an error and returns nil
 ---@return nil | tts__Object[] | tts__IndexedSimpleObjectState[]
 function Object.getObjects() end
 
---- If this object is a scripting trigger, bag or deck, returns the objects contained within. Otherwise, logs an error and returns nil
+--- If this object is a zone, bag or deck, returns the objects contained within. Otherwise, logs an error and returns nil
 ---@return tts__IndexedSimpleObjectState[]
 function Container.getObjects() end
 
---- If this object is a scripting trigger, bag or deck, returns the objects contained within. Otherwise, logs an error and returns nil
+--- If this object is a zone, bag or deck, returns the objects contained within. Otherwise, logs an error and returns nil
 --- If the zone has tags, then only objects with compatible tags will occupy the zone (unless `ignoreTags` is `true`).
 ---@param ignoreTags? boolean If `true` then all objects in the zone will be returned, regardless of tags.
 ---@return tts__Object[]
-function ScriptingTrigger.getObjects(ignoreTags) end
+function Zone.getObjects(ignoreTags) end
 
 --- Combines 2 combinable objects to form a new container (Deck, Stat, etc)
 ---
@@ -710,7 +730,7 @@ function Object.getVectorLines() end
 ---@return tts__Vector
 function Object.getVelocity() end
 
----@return tts__ScriptingTrigger[]
+---@return tts__Zone[]
 function Object.getZones() end
 
 ---@param color? tts__ColorShape|string

--- a/packages/declaration/lua/language-server/ObjectState.def.lua
+++ b/packages/declaration/lua/language-server/ObjectState.def.lua
@@ -246,7 +246,7 @@
 ---@field TriggerForNonCards boolean
 ---@field SplitAddedDecks boolean
 ---@field CombineIntoDecks boolean
----@field CardsPerDeck number
+---@field CardsPerDeck integer
 ---@field Direction tts__LayoutZone_Direction
 ---@field NewObjectFacing tts__LayoutZone_Facing
 ---@field HorizontalGroupPadding number
@@ -261,7 +261,7 @@
 ---@field MeldSortExisting boolean
 ---@field HorizonalSpread number
 ---@field VerticalSpread number
----@field MaxObjectsPerGroup number
+---@field MaxObjectsPerGroup integer
 ---@field AlternateDirection boolean
----@field MaxObjectsPerNewGroup number
+---@field MaxObjectsPerNewGroup integer
 ---@field AllowSwapping boolean

--- a/packages/declaration/lua/language-server/Vector.def.lua
+++ b/packages/declaration/lua/language-server/Vector.def.lua
@@ -17,7 +17,7 @@
 ---@overload fun(src: tts__VectorShape): tts__Vector
 ---@operator add(tts__CharVectorShape): tts__Vector
 ---@operator sub(tts__CharVectorShape): tts__Vector
----@operator mul(tts__CharVectorShape): tts__Vector
+---@operator mul(tts__Vector): tts__Vector
 ---@operator mul(number): tts__Vector
 ---@field __isVector true
 ---@field x number


### PR DESCRIPTION
Adds missing behaviors `Browser`, `Clock`, `Counter`, `LayoutZone`, `RPGFigurine`, `TextTool`.
Standardizes objects to have nullable fields for all behaviours and non-nullable fields when type is constrained.